### PR TITLE
Feature/discard unrecognized tlvs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ ebin
 .eunit
 *~
 .*.swp
+_build

--- a/src/tlv.erl
+++ b/src/tlv.erl
@@ -314,7 +314,11 @@ unpack(?USSD_SESSION_ID=T, Bin) ->
     unpack_int(T, Bin);
 
 unpack(?IMSI=T, Bin) ->
-    unpack_cstring(T, Bin).
+    unpack_cstring(T, Bin);
+
+unpack(Tag, Bin) ->
+    discard_tag(Tag, Bin).
+
 
 pack_multi(_, undefined) ->
     <<>>;
@@ -400,3 +404,6 @@ unpack_cstring(Tag, <<Tag:?TLV_TAG_SIZE, Len:?TLV_LEN_SIZE, Val/binary>>) ->
 
 unpack_octstring(Tag, <<Tag:?TLV_TAG_SIZE, Len:?TLV_LEN_SIZE, Val/binary>>) ->
     pdu_data:bin_to_octstring(Val, Len).
+
+discard_tag(Tag, <<Tag:?TLV_TAG_SIZE, Len:?TLV_LEN_SIZE, Val/binary>>) ->
+    {undefined, binary:part(Val, Len, byte_size(Val) - Len)}.

--- a/src/tlv.erl
+++ b/src/tlv.erl
@@ -25,9 +25,9 @@
 -spec pack_octstring_fixedlen(integer(), binary(), integer()) -> binary().
 -spec pack_octstring_varlen(integer(), binary(), {integer(), integer()}) -> binary().
 -spec pack_octstring_nomax(integer(), binary()) -> binary().
--spec unpack_int(integer(), binary()) -> integer().
--spec unpack_cstring(integer(), binary()) -> iolist().
--spec unpack_octstring(integer(), binary()) -> binary().
+-spec unpack_int(integer(), binary()) -> {integer(), binary()}.
+-spec unpack_cstring(integer(), binary()) -> {iolist(), binary()}.
+-spec unpack_octstring(integer(), binary()) -> {binary(), binary()}.
 
 pack(_, undefined) ->
     <<>>;
@@ -406,4 +406,5 @@ unpack_octstring(Tag, <<Tag:?TLV_TAG_SIZE, Len:?TLV_LEN_SIZE, Val/binary>>) ->
     pdu_data:bin_to_octstring(Val, Len).
 
 discard_tag(Tag, <<Tag:?TLV_TAG_SIZE, Len:?TLV_LEN_SIZE, Val/binary>>) ->
-    {undefined, binary:part(Val, Len, byte_size(Val) - Len)}.
+    <<_:Len/unit:8, Rest/binary>> = Val,
+    {undefined, Rest}.

--- a/test/smpp34pdu_deliver_sm_resp_tests.erl
+++ b/test/smpp34pdu_deliver_sm_resp_tests.erl
@@ -2,8 +2,6 @@
 -include("../include/smpp34pdu.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--record(deliver_sm_resp_custom_tlv, {message_id=?DEFAULT_CSTRING, custom_field=?DEFAULT_CSTRING}).
-
 deliver_sm_resp_test_() ->
     Payload = #deliver_sm_resp{message_id="abcdefghij"},
 
@@ -21,17 +19,3 @@ deliver_sm_resp_test_() ->
 			?_assertEqual(Bin,
 					smpp34pdu_deliver_sm_resp:pack(smpp34pdu_deliver_sm_resp:unpack(Bin)))}
 	].
-
-deliver_sm_resp_custom_tlv_test_() ->
-    Payload0 = #deliver_sm_resp_custom_tlv{message_id="abcdefghij", custom_field = "212312"},
-    Payload = #deliver_sm_resp{message_id="abcdefghij"},
-    Bin = pack(Payload0),
-
-    [
-		{"Unpacking Bin with custom TLV will give Payload without custom TLV",
-            ?_assertEqual(Payload, smpp34pdu_deliver_sm_resp:unpack(Bin))}
-    ].
-
-pack(#deliver_sm_resp_custom_tlv{message_id=MessageId, custom_field = CustomValue}) ->
-	L = [pdu_data:cstring_to_bin(MessageId, 65), pdu_data:cstring_to_bin(CustomValue, 65)],
-	list_to_binary(L).

--- a/test/smpp34pdu_deliver_sm_resp_tests.erl
+++ b/test/smpp34pdu_deliver_sm_resp_tests.erl
@@ -2,8 +2,9 @@
 -include("../include/smpp34pdu.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-record(deliver_sm_resp_custom_tlv, {message_id=?DEFAULT_CSTRING, custom_field=?DEFAULT_CSTRING}).
 
-deliver_sm_resp_test_() -> 
+deliver_sm_resp_test_() ->
     Payload = #deliver_sm_resp{message_id="abcdefghij"},
 
     Bin = <<97,98,99,100,101,102,103,104,105,106,0>>,
@@ -13,10 +14,24 @@ deliver_sm_resp_test_() ->
 			?_assertEqual(Bin,smpp34pdu_deliver_sm_resp:pack(Payload))},
 		{"Unpacking Bin will give Payload",
 			?_assertEqual(Payload, smpp34pdu_deliver_sm_resp:unpack(Bin))},
-		{"Packing and Unpacking Payload will give you Payload", 
+		{"Packing and Unpacking Payload will give you Payload",
 			?_assertEqual(Payload,
 					smpp34pdu_deliver_sm_resp:unpack(smpp34pdu_deliver_sm_resp:pack(Payload)))},
-		{"Unpacking and Packing Bin will give you Bin", 
+		{"Unpacking and Packing Bin will give you Bin",
 			?_assertEqual(Bin,
 					smpp34pdu_deliver_sm_resp:pack(smpp34pdu_deliver_sm_resp:unpack(Bin)))}
 	].
+
+deliver_sm_resp_custom_tlv_test_() ->
+    Payload0 = #deliver_sm_resp_custom_tlv{message_id="abcdefghij", custom_field = "212312"},
+    Payload = #deliver_sm_resp{message_id="abcdefghij"},
+    Bin = pack(Payload0),
+
+    [
+		{"Unpacking Bin with custom TLV will give Payload without custom TLV",
+            ?_assertEqual(Payload, smpp34pdu_deliver_sm_resp:unpack(Bin))}
+    ].
+
+pack(#deliver_sm_resp_custom_tlv{message_id=MessageId, custom_field = CustomValue}) ->
+	L = [pdu_data:cstring_to_bin(MessageId, 65), pdu_data:cstring_to_bin(CustomValue, 65)],
+	list_to_binary(L).

--- a/test/smpp34pdu_submit_sm_tests.erl
+++ b/test/smpp34pdu_submit_sm_tests.erl
@@ -42,7 +42,7 @@ submit_sm_no_tlv_test_() ->
 			?_assertEqual(PayLoad,
 						smpp34pdu_submit_sm:unpack(smpp34pdu_submit_sm:pack(PayLoad)))},
 		{"Unpacking and Packing Bin will give you Bin",
-			?_assertEqual(Bin, 
+			?_assertEqual(Bin,
 						smpp34pdu_submit_sm:pack(smpp34pdu_submit_sm:unpack(Bin)))}
 	].
 
@@ -78,7 +78,7 @@ submit_sm_tlv_usr_msg_ref_test_() ->
 			$0,$0,$0,$0,$1,$4,$0,$0,$0,$0,$0,$0,$0,$0,$0,$R,0,
 			1,1,1,1,11,
 			104,101,108,108,111,32,119,111,114,108,100,
-			2,4,0,2,0,4>>,	
+			2,4,0,2,0,4>>,
 
 	[
 		{"Packing PayLoad will give Bin",
@@ -89,7 +89,7 @@ submit_sm_tlv_usr_msg_ref_test_() ->
 			?_assertEqual(PayLoad,
 						smpp34pdu_submit_sm:unpack(smpp34pdu_submit_sm:pack(PayLoad)))},
 		{"Unpacking and Packing Bin will give you Bin",
-			?_assertEqual(Bin, 
+			?_assertEqual(Bin,
 						smpp34pdu_submit_sm:pack(smpp34pdu_submit_sm:unpack(Bin)))}
 	].
 
@@ -124,7 +124,7 @@ submit_sm_tlv_src_port_test_() ->
 			$0,$0,$0,$0,$1,$4,$0,$0,$0,$0,$0,$0,$0,$0,$0,$R,0,
 			1,1,1,1,11,
 			104,101,108,108,111,32,119,111,114,108,100,
-			2,10,0,2,0,11>>,	
+			2,10,0,2,0,11>>,
 
 	[
 		{"Packing PayLoad will give Bin",
@@ -135,6 +135,45 @@ submit_sm_tlv_src_port_test_() ->
 			?_assertEqual(PayLoad,
 						smpp34pdu_submit_sm:unpack(smpp34pdu_submit_sm:pack(PayLoad)))},
 		{"Unpacking and Packing Bin will give you Bin",
-			?_assertEqual(Bin, 
+			?_assertEqual(Bin,
 						smpp34pdu_submit_sm:pack(smpp34pdu_submit_sm:unpack(Bin)))}
+	].
+
+submit_sm_custom_tlv_unpacking_test_() ->
+	PayLoad = #submit_sm{service_type="CMT",
+		source_addr_ton=2,
+		source_addr_npi=1,
+		source_addr="abcd",
+		dest_addr_ton=2,
+		dest_addr_npi=1,
+		destination_addr="efgh",
+		esm_class=1,
+		protocol_id=2,
+		priority_flag=1,
+		schedule_delivery_time="100716133059001+",
+		validity_period="000014000000000R",
+		registered_delivery=1,
+		replace_if_present_flag=1,
+		data_coding=1,
+		sm_default_msg_id=1,
+		sm_length=11,
+		short_message="hello world",
+		source_port=11},
+
+	Bin = <<67,77,84,0,
+			2,1,
+			97,98,99,100,0,
+			2,1,
+			101,102,103,104,0,
+			1,2,1,
+			$1,$0,$0,$7,$1,$6,$1,$3,$3,$0,$5,$9,$0,$0,$1,$+,0,
+			$0,$0,$0,$0,$1,$4,$0,$0,$0,$0,$0,$0,$0,$0,$0,$R,0,
+			1,1,1,1,11,
+			104,101,108,108,111,32,119,111,114,108,100,
+			2,10,0,2,0,11,
+            255,255,0,2,254,253>>,
+
+	[
+		{"Unpacking Bin with custom TLV will give PayLoad without custom TLV",
+			?_assertEqual(PayLoad, smpp34pdu_submit_sm:unpack(Bin))}
 	].


### PR DESCRIPTION
Currently unpacking pdu with custom TLV fields leads to `function_clause` in `tlv:unpack/2`.
This PR adds a clause which discards unrecognized TLV fields in said function.