### PR TITLE
SMST-103: Add support for custom TLVs in submit_sm

### DIFF
--- a/include/smpp34pdu.hrl
+++ b/include/smpp34pdu.hrl
@@ -93,7 +93,8 @@
                     its_reply_type,
                     its_session_info,
                     ussd_service_op,
-                    ussd_session_id
+                    ussd_session_id,
+                    vendor_specific = #{}
                    }).
 
 -record(submit_sm_resp, {message_id=?DEFAULT_CSTRING, ussd_session_id}).

--- a/include/smpp34pdu_tlv_macros.hrl
+++ b/include/smpp34pdu_tlv_macros.hrl
@@ -5,7 +5,7 @@
 -define(TLV_UNPACK_UNEXPECTED(), unpack_tlv_fields(<<Unexpected:?TLV_TAG_SIZE, _/binary>>=Bin, Body) ->
     {_, Rest} = tlv:unpack(Unexpected, Bin),
     unpack_tlv_fields(Rest, Body)).
--define(TLV_UNPACK_UNEXPECTED(RECORD_NAME), unpack_tlv_fields(<<Unexpected:?TLV_TAG_SIZE, _/binary>>=Bin, Body) ->
+-define(TLV_UNPACK_VENDOR_SPECIFIC(RECORD_NAME), unpack_tlv_fields(<<Unexpected:?TLV_TAG_SIZE, _/binary>>=Bin, Body) when (Unexpected >= 16#1400) and (Unexpected =< 16#3FFF) ->
     case tlv:unpack(Unexpected, Bin) of
         {<<>>, Rest} -> unpack_tlv_fields(Rest, Body);
         {Val, Rest} ->

--- a/include/smpp34pdu_tlv_macros.hrl
+++ b/include/smpp34pdu_tlv_macros.hrl
@@ -5,9 +5,15 @@
 -define(TLV_UNPACK_UNEXPECTED(), unpack_tlv_fields(<<Unexpected:?TLV_TAG_SIZE, _/binary>>=Bin, Body) ->
     {_, Rest} = tlv:unpack(Unexpected, Bin),
     unpack_tlv_fields(Rest, Body)).
+-define(TLV_UNPACK_UNEXPECTED(RECORD_NAME), unpack_tlv_fields(<<Unexpected:?TLV_TAG_SIZE, _/binary>>=Bin, Body) ->
+    case tlv:unpack(Unexpected, Bin) of
+        {<<>>, Rest} -> unpack_tlv_fields(Rest, Body);
+        {Val, Rest} ->
+            #RECORD_NAME{vendor_specific = Vendor} = Body,
+            unpack_tlv_fields(Rest, Body#RECORD_NAME{vendor_specific= Vendor#{Unexpected => Val}})
+    end).
 -define(TLV_UNPACK_FIELD(RECORD_NAME,RECORD_FIELD,FIELD_TAG), unpack_tlv_fields(<<FIELD_TAG:?TLV_TAG_SIZE, _/binary>>=Bin, Body) ->
 	{Val, Rest} = tlv:unpack(FIELD_TAG, Bin),
     unpack_tlv_fields(Rest, Body#RECORD_NAME{RECORD_FIELD=Val})).
-
 
 -endif.

--- a/src/smpp34pdu_submit_sm.erl
+++ b/src/smpp34pdu_submit_sm.erl
@@ -55,7 +55,8 @@ pack(#submit_sm{service_type=SrvType,
 		its_reply_type=ItsReplyType,
 		its_session_info=ItsSessionInfo,
 		ussd_service_op=UssdServiceOp,
-                ussd_session_id=UssdSessionId}) ->
+                ussd_session_id=UssdSessionId,
+        vendor_specific = VendorSpecific }) ->
 
     SmLen = length(ShortMessage),
 
@@ -106,7 +107,8 @@ pack(#submit_sm{service_type=SrvType,
          tlv:pack(?ITS_REPLY_TYPE, ItsReplyType),
          tlv:pack(?ITS_SESSION_INFO, ItsSessionInfo),
          tlv:pack(?USSD_SERVICE_OP, UssdServiceOp),
-         tlv:pack(?USSD_SESSION_ID, UssdSessionId)],
+         tlv:pack(?USSD_SESSION_ID, UssdSessionId),
+         tlv:pack(VendorSpecific)],
 
     list_to_binary(L).
 
@@ -180,4 +182,4 @@ unpack(Bin0) ->
 ?TLV_UNPACK_FIELD(submit_sm, its_session_info, ?ITS_SESSION_INFO);
 ?TLV_UNPACK_FIELD(submit_sm, ussd_service_op, ?USSD_SERVICE_OP);
 ?TLV_UNPACK_FIELD(submit_sm, ussd_session_id, ?USSD_SESSION_ID);
-?TLV_UNPACK_UNEXPECTED().
+?TLV_UNPACK_UNEXPECTED(submit_sm).

--- a/src/smpp34pdu_submit_sm.erl
+++ b/src/smpp34pdu_submit_sm.erl
@@ -55,8 +55,8 @@ pack(#submit_sm{service_type=SrvType,
 		its_reply_type=ItsReplyType,
 		its_session_info=ItsSessionInfo,
 		ussd_service_op=UssdServiceOp,
-        ussd_session_id=UssdSessionId,
-        vendor_specific = VendorSpecific}) ->
+		ussd_session_id=UssdSessionId,
+		vendor_specific = VendorSpecific}) ->
 
     SmLen = length(ShortMessage),
 

--- a/src/smpp34pdu_submit_sm.erl
+++ b/src/smpp34pdu_submit_sm.erl
@@ -55,8 +55,8 @@ pack(#submit_sm{service_type=SrvType,
 		its_reply_type=ItsReplyType,
 		its_session_info=ItsSessionInfo,
 		ussd_service_op=UssdServiceOp,
-                ussd_session_id=UssdSessionId,
-        vendor_specific = VendorSpecific }) ->
+        ussd_session_id=UssdSessionId,
+        vendor_specific = VendorSpecific}) ->
 
     SmLen = length(ShortMessage),
 
@@ -182,4 +182,5 @@ unpack(Bin0) ->
 ?TLV_UNPACK_FIELD(submit_sm, its_session_info, ?ITS_SESSION_INFO);
 ?TLV_UNPACK_FIELD(submit_sm, ussd_service_op, ?USSD_SERVICE_OP);
 ?TLV_UNPACK_FIELD(submit_sm, ussd_session_id, ?USSD_SESSION_ID);
-?TLV_UNPACK_UNEXPECTED(submit_sm).
+?TLV_UNPACK_VENDOR_SPECIFIC(submit_sm);
+?TLV_UNPACK_UNEXPECTED().

--- a/test/smpp34pdu_submit_sm_tests.erl
+++ b/test/smpp34pdu_submit_sm_tests.erl
@@ -158,7 +158,11 @@ submit_sm_custom_tlv_unpacking_test_() ->
 		sm_default_msg_id=1,
 		sm_length=11,
 		short_message="hello world",
-		source_port=11},
+		source_port=11,
+        vendor_specific = #{
+            2 => <<254, 253>>
+        }
+    },
 
 	Bin = <<67,77,84,0,
 			2,1,
@@ -171,9 +175,52 @@ submit_sm_custom_tlv_unpacking_test_() ->
 			1,1,1,1,11,
 			104,101,108,108,111,32,119,111,114,108,100,
 			2,10,0,2,0,11,
-            255,255,0,2,254,253>>,
+            0,2,0,2,254,253>>,
 
 	[
-		{"Unpacking Bin with custom TLV will give PayLoad without custom TLV",
+		{"Unpacking Bin with custom unsupported TLV will give PayLoad without custom TLV",
 			?_assertEqual(PayLoad, smpp34pdu_submit_sm:unpack(Bin))}
+	].
+
+submit_sm_custom_tlv_packing_test_() ->
+	PayLoad = #submit_sm{service_type="CMT",
+		source_addr_ton=2,
+		source_addr_npi=1,
+		source_addr="abcd",
+		dest_addr_ton=2,
+		dest_addr_npi=1,
+		destination_addr="efgh",
+		esm_class=1,
+		protocol_id=2,
+		priority_flag=1,
+		schedule_delivery_time="100716133059001+",
+		validity_period="000014000000000R",
+		registered_delivery=1,
+		replace_if_present_flag=1,
+		data_coding=1,
+		sm_default_msg_id=1,
+		sm_length=11,
+		short_message="hello world",
+		source_port=11,
+        vendor_specific = #{
+            2 => <<254, 253>>
+        }
+    },
+
+	Bin = <<67,77,84,0,
+			2,1,
+			97,98,99,100,0,
+			2,1,
+			101,102,103,104,0,
+			1,2,1,
+			$1,$0,$0,$7,$1,$6,$1,$3,$3,$0,$5,$9,$0,$0,$1,$+,0,
+			$0,$0,$0,$0,$1,$4,$0,$0,$0,$0,$0,$0,$0,$0,$0,$R,0,
+			1,1,1,1,11,
+			104,101,108,108,111,32,119,111,114,108,100,
+			2,10,0,2,0,11,
+            0,2,0,2,254,253>>,
+
+	[
+		{"Packing with custom TLV will honor custom TLVs",
+			?_assertEqual(Bin, smpp34pdu_submit_sm:pack(PayLoad))}
 	].

--- a/test/smpp34pdu_submit_sm_tests.erl
+++ b/test/smpp34pdu_submit_sm_tests.erl
@@ -175,10 +175,11 @@ submit_sm_custom_tlv_unpacking_test_() ->
 			1,1,1,1,11,
 			104,101,108,108,111,32,119,111,114,108,100,
 			2,10,0,2,0,11,
-            0,2,0,2,254,253>>,
+            16#3F, 16#FF,0,2,254,253,
+            16#40, 16#00,0,2,254,253>>,
 
 	[
-		{"Unpacking Bin with custom unsupported TLV will give PayLoad without custom TLV",
+		{"Unpacking Bin with custom TLV will give PayLoad with custom vendor-specific TLV",
 			?_assertEqual(PayLoad, smpp34pdu_submit_sm:unpack(Bin))}
 	].
 
@@ -203,7 +204,7 @@ submit_sm_custom_tlv_packing_test_() ->
 		short_message="hello world",
 		source_port=11,
         vendor_specific = #{
-            2 => <<254, 253>>
+            16#3FFF => <<254, 253>>
         }
     },
 
@@ -218,7 +219,7 @@ submit_sm_custom_tlv_packing_test_() ->
 			1,1,1,1,11,
 			104,101,108,108,111,32,119,111,114,108,100,
 			2,10,0,2,0,11,
-            0,2,0,2,254,253>>,
+            16#3F, 16#FF,0,2,254,253>>,
 
 	[
 		{"Packing with custom TLV will honor custom TLVs",

--- a/test/smpp34pdu_submit_sm_tests.erl
+++ b/test/smpp34pdu_submit_sm_tests.erl
@@ -203,9 +203,9 @@ submit_sm_custom_tlv_packing_test_() ->
 		sm_length=11,
 		short_message="hello world",
 		source_port=11,
-        vendor_specific = #{
+		vendor_specific = #{
             16#3FFF => <<254, 253>>
-        }
+		}
     },
 
 	Bin = <<67,77,84,0,

--- a/test/smpp34pdu_submit_sm_tests.erl
+++ b/test/smpp34pdu_submit_sm_tests.erl
@@ -159,9 +159,9 @@ submit_sm_custom_tlv_unpacking_test_() ->
 		sm_length=11,
 		short_message="hello world",
 		source_port=11,
-        vendor_specific = #{
-            2 => <<254, 253>>
-        }
+		vendor_specific = #{
+			2 => <<254, 253>>
+		}
     },
 
 	Bin = <<67,77,84,0,
@@ -175,8 +175,8 @@ submit_sm_custom_tlv_unpacking_test_() ->
 			1,1,1,1,11,
 			104,101,108,108,111,32,119,111,114,108,100,
 			2,10,0,2,0,11,
-            16#3F, 16#FF,0,2,254,253,
-            16#40, 16#00,0,2,254,253>>,
+			16#3F, 16#FF,0,2,254,253,
+			16#40, 16#00,0,2,254,253>>,
 
 	[
 		{"Unpacking Bin with custom TLV will give PayLoad with custom vendor-specific TLV",
@@ -204,7 +204,7 @@ submit_sm_custom_tlv_packing_test_() ->
 		short_message="hello world",
 		source_port=11,
 		vendor_specific = #{
-            16#3FFF => <<254, 253>>
+			16#3FFF => <<254, 253>>
 		}
     },
 
@@ -219,7 +219,7 @@ submit_sm_custom_tlv_packing_test_() ->
 			1,1,1,1,11,
 			104,101,108,108,111,32,119,111,114,108,100,
 			2,10,0,2,0,11,
-            16#3F, 16#FF,0,2,254,253>>,
+			16#3F, 16#FF,0,2,254,253>>,
 
 	[
 		{"Packing with custom TLV will honor custom TLVs",


### PR DESCRIPTION
The time has come for vendor-specific TLV support.
For now we need to proxy them from smsc to esme, therefore implemented packing and unpacking custom TLVs for `submit_sm` into `vendor_specific` field, containing map of tags and corresponding binaries.