### PR TITLE
USSD-411: Add fields ussd_service_op and ussd_session_id to data_sm

### DIFF
--- a/include/smpp34pdu.hrl
+++ b/include/smpp34pdu.hrl
@@ -197,7 +197,9 @@
                   alert_on_message_delivery,
                   language_indicator,
                   its_reply_type,
-                  its_session_info}).
+                  its_session_info,
+                  ussd_service_op,
+                  ussd_session_id}).
 
 
 -record(data_sm_resp, {message_id=?DEFAULT_CSTRING,

--- a/src/smpp34pdu_data_sm.erl
+++ b/src/smpp34pdu_data_sm.erl
@@ -60,8 +60,8 @@ pack(#data_sm{service_type=SrvType,
 		language_indicator=LanguageIndicator,
 		its_reply_type=ItsReplyType,
 		its_session_info=ItsSessionInfo,
-        ussd_service_op=UssdServiceOp,
-        ussd_session_id=UssdSessionId}) ->
+		ussd_service_op=UssdServiceOp,
+		ussd_session_id=UssdSessionId}) ->
 
 		L = [cstring_to_bin(SrvType, 6),
 					integer_to_bin(SrcAddrTon, 1),
@@ -111,8 +111,8 @@ pack(#data_sm{service_type=SrvType,
 					tlv:pack(?LANGUAGE_INDICATOR, LanguageIndicator),
 					tlv:pack(?ITS_REPLY_TYPE, ItsReplyType),
 					tlv:pack(?ITS_SESSION_INFO, ItsSessionInfo),
-                    tlv:pack(?USSD_SERVICE_OP, UssdServiceOp),
-                    tlv:pack(?USSD_SESSION_ID, UssdSessionId)],
+					tlv:pack(?USSD_SERVICE_OP, UssdServiceOp),
+					tlv:pack(?USSD_SESSION_ID, UssdSessionId)],
 
 		list_to_binary(L).
 

--- a/src/smpp34pdu_data_sm.erl
+++ b/src/smpp34pdu_data_sm.erl
@@ -59,7 +59,9 @@ pack(#data_sm{service_type=SrvType,
 		alert_on_message_delivery=AlertOnMsgDelivery,
 		language_indicator=LanguageIndicator,
 		its_reply_type=ItsReplyType,
-		its_session_info=ItsSessionInfo}) ->
+		its_session_info=ItsSessionInfo,
+        ussd_service_op=UssdServiceOp,
+        ussd_session_id=UssdSessionId}) ->
 
 		L = [cstring_to_bin(SrvType, 6),
 					integer_to_bin(SrcAddrTon, 1),
@@ -108,7 +110,9 @@ pack(#data_sm{service_type=SrvType,
 					tlv:pack(?ALERT_ON_MESSAGE_DELIVERY, AlertOnMsgDelivery),
 					tlv:pack(?LANGUAGE_INDICATOR, LanguageIndicator),
 					tlv:pack(?ITS_REPLY_TYPE, ItsReplyType),
-					tlv:pack(?ITS_SESSION_INFO, ItsSessionInfo)],
+					tlv:pack(?ITS_SESSION_INFO, ItsSessionInfo),
+                    tlv:pack(?USSD_SERVICE_OP, UssdServiceOp),
+                    tlv:pack(?USSD_SESSION_ID, UssdSessionId)],
 
 		list_to_binary(L).
 
@@ -174,4 +178,6 @@ unpack(Bin0) ->
 ?TLV_UNPACK_FIELD(data_sm, language_indicator, ?LANGUAGE_INDICATOR);
 ?TLV_UNPACK_FIELD(data_sm, its_reply_type, ?ITS_REPLY_TYPE);
 ?TLV_UNPACK_FIELD(data_sm, its_session_info, ?ITS_SESSION_INFO);
+?TLV_UNPACK_FIELD(data_sm, ussd_service_op, ?USSD_SERVICE_OP);
+?TLV_UNPACK_FIELD(data_sm, ussd_session_id, ?USSD_SESSION_ID);
 ?TLV_UNPACK_UNEXPECTED().

--- a/test/smpp34pdu_submit_sm_tests.erl
+++ b/test/smpp34pdu_submit_sm_tests.erl
@@ -160,7 +160,7 @@ submit_sm_custom_tlv_unpacking_test_() ->
 		short_message="hello world",
 		source_port=11,
 		vendor_specific = #{
-			2 => <<254, 253>>
+			16#3FFF => <<254, 253>>
 		}
     },
 
@@ -175,8 +175,7 @@ submit_sm_custom_tlv_unpacking_test_() ->
 			1,1,1,1,11,
 			104,101,108,108,111,32,119,111,114,108,100,
 			2,10,0,2,0,11,
-			16#3F, 16#FF,0,2,254,253,
-			16#40, 16#00,0,2,254,253>>,
+			16#3F, 16#FF,0,2,254,253>>,
 
 	[
 		{"Unpacking Bin with custom TLV will give PayLoad with custom vendor-specific TLV",


### PR DESCRIPTION
This PR adds support for optional TLVs `ussd_service_op` and `ussd_session_id` for `data_sm`. 